### PR TITLE
Enable tag drift

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -290,6 +290,9 @@ func (a *Agent) consulConfig() *consul.Config {
 	if a.config.SessionTTLMinRaw != "" {
 		base.SessionTTLMin = a.config.SessionTTLMin
 	}
+	if a.config.EnableTagDrift {
+		base.EnableTagDrift = false
+	}
 
 	// Format the build string
 	revision := a.config.Revision

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -109,6 +109,8 @@ func (c *Command) readConfig() *Config {
 		"number of retries for joining -wan")
 	cmdFlags.StringVar(&retryIntervalWan, "retry-interval-wan", "",
 		"interval between join -wan attempts")
+	cmdFlags.BoolVar(&cmdConfig.EnableTagDrift, "enable_tag_drift", false,
+		"enable tag drift - ignore tags during anti-entropy")
 
 	if err := cmdFlags.Parse(c.args); err != nil {
 		return nil

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -395,6 +395,10 @@ type Config struct {
 	// Minimum Session TTL
 	SessionTTLMin    time.Duration `mapstructure:"-"`
 	SessionTTLMinRaw string        `mapstructure:"session_ttl_min"`
+
+	// EnableTagDrift when true will inhibit comparison
+	// of service tags during anti-entropy
+	EnableTagDrift bool `mapstructure:"enable_tag_drift"`
 }
 
 // UnixSocketPermissions contains information about a unix socket, and
@@ -1067,6 +1071,9 @@ func MergeConfig(a, b *Config) *Config {
 		for field, value := range b.HTTPAPIResponseHeaders {
 			result.HTTPAPIResponseHeaders[field] = value
 		}
+	}
+	if b.EnableTagDrift {
+		result.EnableTagDrift = false
 	}
 
 	// Copy the start join addresses

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -555,6 +555,10 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	if !config.EnableTagDrift {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// ACLs
 	input = `{"acl_token": "1234", "acl_datacenter": "dc2",
 	"acl_ttl": "60s", "acl_down_policy": "deny",
@@ -1214,6 +1218,7 @@ func TestMergeConfig(t *testing.T) {
 			RPC:        &net.TCPAddr{},
 			RPCRaw:     "127.0.0.5:1233",
 		},
+		EnableTagDrift: false,
 	}
 
 	c := MergeConfig(a, b)

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -378,19 +378,13 @@ func (l *localState) setSyncState() error {
 			continue
 		}
 
-		var existingTags []string
 		if l.config.EnableTagDrift {
-			l.logger.Printf("[DEBUG] Tag drift enabled.")
-			existingTags = existing.Tags
-			existing.Tags = nil
-			service.Tags = nil
+			l.logger.Printf("[DEBUG] Tag drift enabled.  Ignoring any tag modifications in service definition")
+			service.Tags = existing.Tags
 		}
 
 		// If our definition is different, we need to update it
 		equal := reflect.DeepEqual(existing, service)
-		if l.config.EnableTagDrift {
-			existing.Tags = existingTags
-		}
 		l.serviceStatus[id] = syncStatus{inSync: equal}
 	}
 

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -377,7 +377,7 @@ func (l *localState) setSyncState() error {
 			l.serviceStatus[id] = syncStatus{remoteDelete: true}
 			continue
 		}
-		
+
 		if l.config.EnableTagDrift {
 			l.logger.Printf("[DEBUG] Tag drift enabled.")
 			existing.Tags = nil

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -377,6 +377,12 @@ func (l *localState) setSyncState() error {
 			l.serviceStatus[id] = syncStatus{remoteDelete: true}
 			continue
 		}
+		
+		if l.config.EnableTagDrift {
+			l.logger.Printf("[DEBUG] Tag drift enabled.")
+			existing.Tags = nil
+			service.Tags = nil
+		}
 
 		// If our definition is different, we need to update it
 		equal := reflect.DeepEqual(existing, service)

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -378,14 +378,19 @@ func (l *localState) setSyncState() error {
 			continue
 		}
 
+		var existingTags []string
 		if l.config.EnableTagDrift {
 			l.logger.Printf("[DEBUG] Tag drift enabled.")
+			existingTags = existing.Tags
 			existing.Tags = nil
 			service.Tags = nil
 		}
 
 		// If our definition is different, we need to update it
 		equal := reflect.DeepEqual(existing, service)
+		if l.config.EnableTagDrift {
+			existing.Tags = existingTags
+		}
 		l.serviceStatus[id] = syncStatus{inSync: equal}
 	}
 

--- a/consul/config.go
+++ b/consul/config.go
@@ -203,7 +203,7 @@ type Config struct {
 	// UserEventHandler callback can be used to handle incoming
 	// user events. This function should not block.
 	UserEventHandler func(serf.UserEvent)
-	
+
 	// EnableTagDrift when true will inhibit comparison
 	// of service tags during anti-entropy
 	EnableTagDrift bool

--- a/consul/config.go
+++ b/consul/config.go
@@ -203,6 +203,10 @@ type Config struct {
 	// UserEventHandler callback can be used to handle incoming
 	// user events. This function should not block.
 	UserEventHandler func(serf.UserEvent)
+	
+	// EnableTagDrift when true will inhibit comparison
+	// of service tags during anti-entropy
+	EnableTagDrift bool
 }
 
 // CheckVersion is used to check if the ProtocolVersion is valid


### PR DESCRIPTION
Adding EnableTagDrift config parameter.  When TRUE it will 'nil out' the tags members when comparing service definitions during anti-entropy.  Thus effectively ignoring tags.  The purpose of this would be to allow external nodes to modify tags of service registrations.  For example: We want Redis instances to register as a service but Sentinel to maintain the tags.